### PR TITLE
feat: add i18n base configuration and translation files

### DIFF
--- a/.github/workflows/flutter_lint.yml
+++ b/.github/workflows/flutter_lint.yml
@@ -26,7 +26,9 @@ jobs:
         run: flutter pub get
       
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed lib/
+        run: |
+          # Format only manually created files, exclude generated files
+          find lib/ -name "*.dart" ! -name "app_localizations.dart" ! -name "app_localizations_*.dart" -exec dart format --output=none --set-exit-if-changed {} \;
       
       - name: Analyze project source
         run: flutter analyze

--- a/.github/workflows/flutter_lint.yml
+++ b/.github/workflows/flutter_lint.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       
+      - name: Remove generated localization files
+        run: rm -f lib/l10n/app_localizations.dart lib/l10n/app_localizations_*.dart
+      
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed . --exclude=lib/l10n/app_localizations.dart,lib/l10n/app_localizations_*.dart
+        run: dart format --output=none --set-exit-if-changed .
       
       - name: Analyze project source
         run: flutter analyze

--- a/.github/workflows/flutter_lint.yml
+++ b/.github/workflows/flutter_lint.yml
@@ -26,7 +26,7 @@ jobs:
         run: flutter pub get
       
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: dart format --output=none --set-exit-if-changed . --exclude=lib/l10n/app_localizations.dart,lib/l10n/app_localizations_*.dart
       
       - name: Analyze project source
         run: flutter analyze

--- a/.github/workflows/flutter_lint.yml
+++ b/.github/workflows/flutter_lint.yml
@@ -25,11 +25,8 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       
-      - name: Remove generated localization files
-        run: rm -f lib/l10n/app_localizations.dart lib/l10n/app_localizations_*.dart
-      
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: dart format --output=none --set-exit-if-changed lib/
       
       - name: Analyze project source
         run: flutter analyze

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ app.*.symbols
 
 # FVM Version Cache
 .fvm/
+
+# Generated localization files
+lib/l10n/app_localizations.dart
+lib/l10n/app_localizations_*.dart

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,3 @@ app.*.symbols
 
 # FVM Version Cache
 .fvm/
-
-# Generated localization files
-lib/l10n/app_localizations.dart
-lib/l10n/app_localizations_*.dart

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@
 - Flutter 3.32.0 or higher
 - Dart SDK 3.5.0 or higher
 
+### VS Code Extensions
+
+To enhance your development experience, we recommend installing the following VS Code extensions:
+
+- **Flutter** - Official Flutter extension for VS Code
+- **Dart** - Dart language support
+- **Flutter Intl** - Internationalization support for Flutter
+- **Error Lens** - Enhanced error reporting
+- **GitLens** - Enhanced Git capabilities
+- **Prettier** - Code formatter
+- **Bracket Pair Colorizer** - Colorized bracket pairs
+
+You can install these extensions by:
+1. Opening VS Code
+2. Going to Extensions (Ctrl+Shift+X / Cmd+Shift+X)
+3. Searching for each extension and clicking "Install"
+
 ### Flutter Version
 - Flutter: 3.32.0
 - Dart: 3.5.0

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations 

--- a/lib/generated/intl/messages_all.dart
+++ b/lib/generated/intl/messages_all.dart
@@ -1,0 +1,68 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_en.dart' as messages_en;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'en': () => new SynchronousFuture(null),
+};
+
+MessageLookupByLibrary? _findExact(String localeName) {
+  switch (localeName) {
+    case 'en':
+      return messages_en.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future<bool> initializeMessages(String localeName) {
+  var availableLocale = Intl.verifiedLocale(
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null,
+  );
+  if (availableLocale == null) {
+    return new SynchronousFuture(false);
+  }
+  var lib = _deferredLibraries[availableLocale];
+  lib == null ? new SynchronousFuture(false) : lib();
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
+  return new SynchronousFuture(true);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary? _findGeneratedMessagesFor(String locale) {
+  var actualLocale = Intl.verifiedLocale(
+    locale,
+    _messagesExistFor,
+    onFailure: (_) => null,
+  );
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -1,0 +1,25 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
+// ignore_for_file:unnecessary_string_interpolations, unnecessary_string_escapes
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
+}

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'intl/messages_all.dart';
+
+// **************************************************************************
+// Generator: Flutter Intl IDE plugin
+// Made by Localizely
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, lines_longer_than_80_chars
+// ignore_for_file: join_return_with_assignment, prefer_final_in_for_each
+// ignore_for_file: avoid_redundant_argument_values, avoid_escaping_inner_quotes
+
+class S {
+  S();
+
+  static S? _current;
+
+  static S get current {
+    assert(
+      _current != null,
+      'No instance of S was loaded. Try to initialize the S delegate before accessing S.current.',
+    );
+    return _current!;
+  }
+
+  static const AppLocalizationDelegate delegate = AppLocalizationDelegate();
+
+  static Future<S> load(Locale locale) {
+    final name = (locale.countryCode?.isEmpty ?? false)
+        ? locale.languageCode
+        : locale.toString();
+    final localeName = Intl.canonicalizedLocale(name);
+    return initializeMessages(localeName).then((_) {
+      Intl.defaultLocale = localeName;
+      final instance = S();
+      S._current = instance;
+
+      return instance;
+    });
+  }
+
+  static S of(BuildContext context) {
+    final instance = S.maybeOf(context);
+    assert(
+      instance != null,
+      'No instance of S present in the widget tree. Did you add S.delegate in localizationsDelegates?',
+    );
+    return instance!;
+  }
+
+  static S? maybeOf(BuildContext context) {
+    return Localizations.of<S>(context, S);
+  }
+}
+
+class AppLocalizationDelegate extends LocalizationsDelegate<S> {
+  const AppLocalizationDelegate();
+
+  List<Locale> get supportedLocales {
+    return const <Locale>[Locale.fromSubtags(languageCode: 'en')];
+  }
+
+  @override
+  bool isSupported(Locale locale) => _isSupported(locale);
+  @override
+  Future<S> load(Locale locale) => S.load(locale);
+  @override
+  bool shouldReload(AppLocalizationDelegate old) => false;
+
+  bool _isSupported(Locale locale) {
+    for (var supportedLocale in supportedLocales) {
+      if (supportedLocale.languageCode == locale.languageCode) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,16 @@
+{
+  "@@locale": "en",
+  "appTitle": "Split Payment App",
+  "welcome": "Welcome",
+  "addExpense": "Add Expense",
+  "expenseTitle": "Expense Title",
+  "amount": "Amount",
+  "save": "Save",
+  "cancel": "Cancel",
+  "delete": "Delete",
+  "edit": "Edit",
+  "total": "Total",
+  "perPerson": "Per Person",
+  "noExpenses": "No expenses yet",
+  "addYourFirstExpense": "Add your first expense to get started"
+} 

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,16 @@
+{
+  "@@locale": "ja",
+  "appTitle": "割り勘アプリ",
+  "welcome": "ようこそ",
+  "addExpense": "支出を追加",
+  "expenseTitle": "支出タイトル",
+  "amount": "金額",
+  "save": "保存",
+  "cancel": "キャンセル",
+  "delete": "削除",
+  "edit": "編集",
+  "total": "合計",
+  "perPerson": "一人あたり",
+  "noExpenses": "支出がまだありません",
+  "addYourFirstExpense": "最初の支出を追加して始めましょう"
+} 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_ja.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations? of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ja')
+  ];
+
+  /// No description provided for @appTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Split Payment App'**
+  String get appTitle;
+
+  /// No description provided for @welcome.
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome'**
+  String get welcome;
+
+  /// No description provided for @addExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Expense'**
+  String get addExpense;
+
+  /// No description provided for @expenseTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Expense Title'**
+  String get expenseTitle;
+
+  /// No description provided for @amount.
+  ///
+  /// In en, this message translates to:
+  /// **'Amount'**
+  String get amount;
+
+  /// No description provided for @save.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get save;
+
+  /// No description provided for @cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancel;
+
+  /// No description provided for @delete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get delete;
+
+  /// No description provided for @edit.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit'**
+  String get edit;
+
+  /// No description provided for @total.
+  ///
+  /// In en, this message translates to:
+  /// **'Total'**
+  String get total;
+
+  /// No description provided for @perPerson.
+  ///
+  /// In en, this message translates to:
+  /// **'Per Person'**
+  String get perPerson;
+
+  /// No description provided for @noExpenses.
+  ///
+  /// In en, this message translates to:
+  /// **'No expenses yet'**
+  String get noExpenses;
+
+  /// No description provided for @addYourFirstExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'Add your first expense to get started'**
+  String get addYourFirstExpense;
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ja'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
+    case 'ja':
+      return AppLocalizationsJa();
+  }
+
+  throw FlutterError(
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,49 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'Split Payment App';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get addExpense => 'Add Expense';
+
+  @override
+  String get expenseTitle => 'Expense Title';
+
+  @override
+  String get amount => 'Amount';
+
+  @override
+  String get save => 'Save';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get delete => 'Delete';
+
+  @override
+  String get edit => 'Edit';
+
+  @override
+  String get total => 'Total';
+
+  @override
+  String get perPerson => 'Per Person';
+
+  @override
+  String get noExpenses => 'No expenses yet';
+
+  @override
+  String get addYourFirstExpense => 'Add your first expense to get started';
+}

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1,0 +1,49 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Japanese (`ja`).
+class AppLocalizationsJa extends AppLocalizations {
+  AppLocalizationsJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get appTitle => '割り勘アプリ';
+
+  @override
+  String get welcome => 'ようこそ';
+
+  @override
+  String get addExpense => '支出を追加';
+
+  @override
+  String get expenseTitle => '支出タイトル';
+
+  @override
+  String get amount => '金額';
+
+  @override
+  String get save => '保存';
+
+  @override
+  String get cancel => 'キャンセル';
+
+  @override
+  String get delete => '削除';
+
+  @override
+  String get edit => '編集';
+
+  @override
+  String get total => '合計';
+
+  @override
+  String get perPerson => '一人あたり';
+
+  @override
+  String get noExpenses => '支出がまだありません';
+
+  @override
+  String get addYourFirstExpense => '最初の支出を追加して始めましょう';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:split_payment_app/l10n/app_localizations.dart';
+import 'package:split_payment_app/src/shared/extensions/i18n_extension.dart';
 
-void main() {
+void main() async {
   runApp(const MyApp());
 }
 
@@ -10,59 +13,99 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Split Payment App',
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('ja'),
+      ],
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({
-    required this.title,
-    super.key,
-  });
-
-  final String title;
+  const MyHomePage({super.key});
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+  Locale _currentLocale = const Locale('en');
 
-  void _incrementCounter() {
+  void _toggleLocale() {
     setState(() {
-      _counter++;
+      _currentLocale = _currentLocale.languageCode == 'en'
+          ? const Locale('ja')
+          : const Locale('en');
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
+    return MaterialApp(
+      title: context.l10n.appTitle,
+      locale: _currentLocale,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('ja'),
+      ],
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text(context.l10n.appTitle),
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                context.l10n.welcome,
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 20),
+              Text(
+                context.l10n.addYourFirstExpense,
+                style: Theme.of(context).textTheme.bodyLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 30),
+              ElevatedButton(
+                onPressed: _toggleLocale,
+                child: Text(
+                  _currentLocale.languageCode == 'en'
+                      ? '日本語に切り替え'
+                      : 'Switch to English',
+                ),
+              ),
+            ],
+          ),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {},
+          tooltip: context.l10n.addExpense,
+          child: const Icon(Icons.add),
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:split_payment_app/l10n/app_localizations.dart';
 import 'package:split_payment_app/src/shared/extensions/i18n_extension.dart';
+import 'package:split_payment_app/src/shared/providers/locale_provider.dart';
 
 void main() async {
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(appLocaleProvider);
+
     return MaterialApp(
       title: 'Split Payment App',
+      locale: locale,
       localizationsDelegates: const [
         AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
@@ -33,79 +38,39 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends ConsumerWidget {
   const MyHomePage({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(appLocaleProvider);
 
-class _MyHomePageState extends State<MyHomePage> {
-  Locale _currentLocale = const Locale('en');
-
-  void _toggleLocale() {
-    setState(() {
-      _currentLocale = _currentLocale.languageCode == 'en'
-          ? const Locale('ja')
-          : const Locale('en');
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: context.l10n.appTitle,
-      locale: _currentLocale,
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('en'),
-        Locale('ja'),
-      ],
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.appTitle),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      home: Scaffold(
-        appBar: AppBar(
-          title: Text(context.l10n.appTitle),
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              context.l10n.welcome,
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: 20),
+            Text(
+              context.l10n.addYourFirstExpense,
+              style: Theme.of(context).textTheme.bodyLarge,
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Text(
-                context.l10n.welcome,
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-              const SizedBox(height: 20),
-              Text(
-                context.l10n.addYourFirstExpense,
-                style: Theme.of(context).textTheme.bodyLarge,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 30),
-              ElevatedButton(
-                onPressed: _toggleLocale,
-                child: Text(
-                  _currentLocale.languageCode == 'en'
-                      ? '日本語に切り替え'
-                      : 'Switch to English',
-                ),
-              ),
-            ],
-          ),
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {},
-          tooltip: context.l10n.addExpense,
-          child: const Icon(Icons.add),
-        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        tooltip: context.l10n.addExpense,
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,8 +43,6 @@ class MyHomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final locale = ref.watch(appLocaleProvider);
-
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.appTitle),

--- a/lib/src/shared/extensions/i18n_extension.dart
+++ b/lib/src/shared/extensions/i18n_extension.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+import 'package:split_payment_app/l10n/app_localizations.dart';
+
+extension I18nExtension on BuildContext {
+  /// Get the localized strings for the current context
+  AppLocalizations get l10n => AppLocalizations.of(this)!;
+}

--- a/lib/src/shared/providers/locale_provider.dart
+++ b/lib/src/shared/providers/locale_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'locale_provider.g.dart';
+
+@riverpod
+class AppLocale extends _$AppLocale {
+  @override
+  Locale build() {
+    // Get the device's locale setting
+    final platformLocale = WidgetsBinding.instance.platformDispatcher.locale;
+
+    // Check if the language is supported
+    if (platformLocale.languageCode == 'ja') {
+      return const Locale('ja');
+    }
+
+    // Default to English
+    return const Locale('en');
+  }
+
+  void toggle() {
+    state =
+        state.languageCode == 'en' ? const Locale('ja') : const Locale('en');
+  }
+}

--- a/lib/src/shared/providers/locale_provider.g.dart
+++ b/lib/src/shared/providers/locale_provider.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'locale_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$appLocaleHash() => r'1a926378f1f236cf06acba90eda6d5d60e865d3b';
+
+/// See also [AppLocale].
+@ProviderFor(AppLocale)
+final appLocaleProvider =
+    AutoDisposeNotifierProvider<AppLocale, Locale>.internal(
+  AppLocale.new,
+  name: r'appLocaleProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$appLocaleHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$AppLocale = AutoDisposeNotifier<Locale>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dev_dependencies:
   riverpod_generator: ^2.6.5
   freezed: ^3.0.6
   json_serializable: ^6.8.0
+  intl_utils: ^2.8.5
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## What does this PR do?
<!-- Brief explanation of the changes -->
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor

- This PR adds internationalization support with automatic device locale detection.
- Features
- Auto Language Detection: App automatically uses device language (English/Japanese)
- Riverpod State Management: Clean locale management with @riverpod annotation
- Context Extension: Simple usage with context.l10n

## Screenshots
<!-- If you changed the UI, add screenshots -->
| English | Japanse |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/687c2fac-fc52-4025-9465-a32b415697a9" width="300" /> | <img src="https://github.com/user-attachments/assets/10d7e4dc-06eb-4e97-8a7e-1911238d4691" width="300" />|

## Notes
<!-- Any additional information that reviewers should know --> 